### PR TITLE
fix: Reference Vagrant VM using "worker"

### DIFF
--- a/tp/containers/vagrant/kubeadm/Vagrantfile
+++ b/tp/containers/vagrant/kubeadm/Vagrantfile
@@ -14,9 +14,9 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "worker" do |worker|
-    node.vm.hostname = "worker"
-    node.vm.network "private_network", ip: "10.42.42.43", name: "vboxnet0"
-    node.vm.provider "virtualbox" do |vb|
+    worker.vm.hostname = "worker"
+    worker.vm.network "private_network", ip: "10.42.42.43", name: "vboxnet0"
+    worker.vm.provider "virtualbox" do |vb|
       vb.cpus = "1"
       vb.memory = "1024"
     end


### PR DESCRIPTION
Vagrant config is invalid due to the second `"worker"` VM being referenced as `"node"`