### PR TITLE
fix: Get ClusterConfig before issuing kubeconfig

### DIFF
--- a/tp/containers/k8s-rbac.fr.md
+++ b/tp/containers/k8s-rbac.fr.md
@@ -26,10 +26,11 @@ l'utilisateur. Pour que ce certificat soit valide, ce certificat doit avoir ét�
 signé par l'autorité de certification interne à Kubernetes.
 
 Pour créer ce certificat, on va utiliser une fonction de `kubeadm`. Pour cela,
-connectez vous à un noeud master et lancez la commande suivante :
+connectez vous à un noeud master et lancez les commandes suivantes :
 
 ```console
-$ kubeadm alpha kubeconfig user --client-name red > kubeconfig
+$ kubectl get cm -n kube-system kubeadm-config -o jsonpath='{ .data.ClusterConfiguration }' > cluster-configuration.yaml
+$ kubeadm alpha kubeconfig user --client-name red --config=cluster-configuration.yaml > kubeconfig
 ```
 
 Le kubeconfig généré contient les crédentials pour un user `red`.

--- a/tp/containers/k8s-rbac.fr.md
+++ b/tp/containers/k8s-rbac.fr.md
@@ -14,7 +14,7 @@ Nous allons voir les différentes options offertes par Kubernetes :
 
 ## Prérequis
 
-- Cluster Kubernetes >= 1.19
+- Cluster Kubernetes >= 1.20
 - `kubectl`
 - `kubeadm`
 


### PR DESCRIPTION
Retrieve ClusterConfiguration from kubeadm-config ConfigMapto pass as argument to kubeadm alpha kubeconfig user

The `--config` flag from `kubeadm alpha kubeconfig user` is now mandatory (Kubernetes version 1.20), retrieve the current ClusterConfiguration before trying to create kubeconfig